### PR TITLE
Javascript in keyword returns index for arrays; hence points[pos] is required to display point values.

### DIFF
--- a/raphael-radar-0.0.0.js
+++ b/raphael-radar-0.0.0.js
@@ -13,9 +13,9 @@ Raphael.fn.polygon = function (params, points)
     var poly = this.path(path_string);
     poly.attr(params);
 
-    /* Why this doesnt work?
+    /*
     for( var pos in points){
-      console.log(pos);
+      console.log(points[pos]);
     }
     */
 


### PR DESCRIPTION
Modified polygon function debug info to display points instead of indexes within the array
